### PR TITLE
Fix Brakeman SQL Injection Issues

### DIFF
--- a/app/helpers/alchemy/pages_helper.rb
+++ b/app/helpers/alchemy/pages_helper.rb
@@ -166,7 +166,7 @@ module Alchemy
       pages = page.children.accessible_by(current_ability, :see)
       pages = pages.restricted if options.delete(:restricted_only)
       if depth = options[:deepness]
-        pages = pages.where("#{Page.table_name}.depth <= #{depth}")
+        pages = pages.where("#{Page.table_name}.depth <= ?", depth)
       end
       if options[:reverse]
         pages.reverse!

--- a/app/models/alchemy/element.rb
+++ b/app/models/alchemy/element.rb
@@ -321,9 +321,15 @@ module Alchemy
     #   Pass an element name to get previous of this kind.
     #
     def previous_or_next(dir, name = nil)
-      elements = page.elements.published.where("#{self.class.table_name}.position #{dir} #{position}")
+      options = if dir == '>'
+                  {order: :asc, direction: dir}
+                else
+                  {order: :desc, direction: '<'}
+                end
+      query = "#{self.class.table_name}.position #{options[:direction]} ?"
+      elements = page.elements.published.where(query, position)
       elements = elements.named(name) if name.present?
-      elements.reorder("position #{dir == '>' ? 'ASC' : 'DESC'}").limit(1).first
+      elements.reorder(position: options[:order]).limit(1).first
     end
 
     # Returns all cells from given page this element could be placed in.

--- a/app/models/alchemy/page.rb
+++ b/app/models/alchemy/page.rb
@@ -474,10 +474,12 @@ module Alchemy
         public: true
       }.update(options)
 
-      pages = self_and_siblings.where(["#{Page.table_name}.lft #{dir} ?", lft])
+      dir = dir == '>' ? '>' : '<'
+      order = dir == '>' ? 'lft' : 'lft DESC'
+      pages = self_and_siblings.where("#{Page.table_name}.lft #{dir} ?", lft)
       pages = options[:public] ? pages.published : pages.not_public
       pages.where(restricted: options[:restricted])
-        .reorder(dir == '>' ? 'lft' : 'lft DESC')
+        .reorder(order)
         .limit(1).first
     end
 


### PR DESCRIPTION
Brakeman indicated 3 potential SQL injection issues. The following
list outlines the issues from highest to lowest severity:

1) `Alchemy::PagesHelper#render_navigation` - If the developer passed
   user-controlled parameters to the `deepness` argument, SQL injection
   would be possible via interpolation inside a where clause.
2) `Alchemy::Page#next_or_previous` - A raw interpolation of the
   `dir` variable in a where clause that could only result from
   malicious use of the `next_or_previous` method (which is private).
3) `Alchemy::Element#previous_or_next` - A raw interpolation of the
   `dir` variable in a where clause. Again, this could only
   result from improper use of the `previous_or_next` private
   method.